### PR TITLE
remove the array definition of output_file

### DIFF
--- a/variables/replace_variables.py
+++ b/variables/replace_variables.py
@@ -177,9 +177,9 @@ def replace_variable_values(content, variables):
     return '\n'.join(lines)
 
 
-def output_audit(content, output_file=[], overwrite=False):
+def output_audit(content, output_file, overwrite=False):
     if output_file:
-        write_file(output_file[0], content, overwrite)
+        write_file(output_file, content, overwrite)
     else:
         print(content)
 


### PR DESCRIPTION
The current code treats output_file as an array and when making a call to write_file it only passes in the first character of the filename i.e. output_file[0].
This bug happens with python 3.7 on Ubuntu.