### PR TITLE
change powershell_args from double to single quote

### DIFF
--- a/batch_create/build_powershell_audit.py
+++ b/batch_create/build_powershell_audit.py
@@ -138,7 +138,7 @@ def convert_script_to_item(source, encode=False, destination=None):
   description          : "{}"
   value_type           : POLICY_TEXT
   value_data           : "{}"
-  powershell_args      : "{}"
+  powershell_args      : '{}'
   ps_encoded_args      : {}
   only_show_cmd_output : YES
   check_type           : {}


### PR DESCRIPTION
Fix the quoting as escaped single quotes work, but escaped double quotes do not.