### PR TITLE
Audit migration script for new DB plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,7 @@ Collection of instructions and Python script to execute CLI scans on a local Nes
 ## nessus_convert/nessus_convert.py
 
 Python script that converts a `.nessus` export to CSV or JSON.
+
+## db_audit_migrate/db_audit_migrate.py
+
+Python script that converts an audit file from the Database plugin to a format supported by the new database specific plugins.

--- a/db_audit_migrate/README.md
+++ b/db_audit_migrate/README.md
@@ -1,0 +1,70 @@
+# DB Audit Migrate
+
+## Description
+
+The __db_audit_migrate.py__ script is a utility to convert audit files that were written for the Database Compliance Check plugin and format them to a new structure to support individual database technology plugins.
+
+This script is provided as-is to attempt to assist in migrating existing database audits to the individual database technology audits.
+
+
+## Operation
+
+### Requirements
+
+- python3 (may work on python2.7+, but didn't test)
+- Audit file to convert
+
+### Process
+
+- Run the command line python tool to convert the audit file.
+
+### Usage
+
+```
+usage: db_audit_migrate.py [-h] [-t] [-v] [-o OUTPUT] [-r] audit [audit ...]
+
+Convert Database audits to individual technology database audits.
+
+positional arguments:
+  audit                 audit file(s) to process
+
+optional arguments:
+  -h, --help            show this help message and exit
+  -t, --timestamp       show timestamp on output
+  -v, --verbose         show verbose output
+  -o OUTPUT, --output OUTPUT
+                        output directory for new audits
+  -r, --replace         overwrite existing files
+```
+
+### Example Run
+
+```Shell Session
+test$ ./db_audit_migrate.py -tv CIS_MySQL_8.0_Enterprise_Benchmark_v1.2.0_Level_1_DB.audit
+2022/09/13 19:58:00 Start
+2022/09/13 19:58:00 1 audit to process.
+2022/09/13 19:58:00 Processing CIS_MySQL_8.0_Enterprise_Benchmark_v1.2.0_Level_1_DB.audit
+2022/09/13 19:58:00  - reading audit
+2022/09/13 19:58:00  - updating check type (39)
+2022/09/13 19:58:00  - adding group policy line to delete (40)
+2022/09/13 19:58:00  * commenting out unsupported unquoted field (50): check_option
+2022/09/13 19:58:00  * commenting out unsupported unquoted field (59): check_option
+2022/09/13 19:58:00  * commenting out unsupported unquoted field (159): check_option
+2022/09/13 19:58:00  * commenting out unsupported unquoted field (188): check_option
+2022/09/13 19:58:00  * commenting out unsupported unquoted field (217): check_option
+2022/09/13 19:58:00  * commenting out unsupported unquoted field (252): check_option
+2022/09/13 19:58:00  * commenting out unsupported unquoted field (287): check_option
+2022/09/13 19:58:00  * commenting out unsupported unquoted field (322): check_option
+2022/09/13 19:58:00  * commenting out unsupported unquoted field (357): check_option
+2022/09/13 19:58:00  * commenting out unsupported unquoted field (392): check_option
+2022/09/13 19:58:00  * commenting out unsupported unquoted field (1411): check_option
+2022/09/13 19:58:00  * commenting out unsupported unquoted field (1703): check_option
+2022/09/13 19:58:00  * commenting out unsupported unquoted field (1712): check_option
+2022/09/13 19:58:00  * commenting out unsupported unquoted field (1811): check_option
+2022/09/13 19:58:00  * commenting out unsupported unquoted field (1884): check_option
+2022/09/13 19:58:00  - adding group policy line to delete (2065)
+2022/09/13 19:58:00  - deleting lines
+2022/09/13 19:58:00 Wrote data to file: ./CIS_MySQL_8.0_Enterprise_Benchmark_v1.2.0_Level_1_DB.audit
+2022/09/13 19:58:00 Done
+test$
+```

--- a/db_audit_migrate/db_audit_migrate.py
+++ b/db_audit_migrate/db_audit_migrate.py
@@ -1,0 +1,283 @@
+#!/usr/bin/env python3
+
+# Description : This script is a utility to convert audit files that were
+#               written for the Database Compliance Check plugin and format
+#               them to a new structure to support individual database
+#               technology plugins.
+
+
+import argparse
+import datetime
+import os
+import re
+import sys
+
+import sql_util
+
+
+show_verbose = False
+show_time = False
+
+check_type_re = re.compile('^\\s*<\\s*check_type\\s*:\\s*"([^"]+)".*>')
+db_type_re = re.compile('^\\s*<\\s*check_type\\s*:\\s*"([^"]+)".*db_type\\s*:\\s*"([^"]+)".*>')
+group_policy_re = re.compile('^\\s*</?\\s*group_policy\\s*(:\\s*"([^"]+)"\\s*)?>')
+open_item_re = re.compile('^\\s*<\\s*custom_item\\s*>')
+close_item_re = re.compile('^\\s*</\\s*custom_item\\s*>')
+field_replace_re = re.compile('^(\\s*[^\\s:]+\\s*: *).*$')
+sql_field_re = re.compile('^ *(sql_(request|types|expect)) *: .*')
+simple_quoted_field_re = re.compile('^ *([a-z0-9_-]+) *: *(["\'])[^\\2]*\\2 *$')
+simple_unquoted_field_re = re.compile('^ *([a-z0-9_-]+) *: *[A-Za-z0-9_-]+ *$')
+select_re = re.compile('(?i)^select (.*?) from')
+
+
+def parse_args(parameters):
+    global show_time, show_verbose
+
+    default_output = '.'
+
+    parser = argparse.ArgumentParser(description=('Convert Database audits '
+                                                  'to individual technology '
+                                                  'database audits.'))
+
+    parser.add_argument('-t', '--timestamp', action='store_true',
+                        help='show timestamp on output')
+    parser.add_argument('-v', '--verbose', action='store_true',
+                        help='show verbose output')
+
+    parser.add_argument('-o', '--output', nargs=1, default=default_output,
+                        help='output directory for new audits')
+    parser.add_argument('-r', '--replace', action='store_true',
+                        help='overwrite existing files')
+
+    parser.add_argument('audit', type=str, nargs='+',
+                        help='audit file(s) to process')
+
+    args = parser.parse_args(parameters)
+
+    if args.timestamp:
+        show_time = True
+    if args.verbose:
+        show_verbose = True
+
+    if isinstance(args.output, list):
+        if len(args.output) > 0:
+            args.output = args.output[0]
+        else:
+            args.output = default_output
+
+    return args
+
+
+def make_list(target=None):
+    if target is None:
+        return []
+    elif isinstance(target, list):
+        return target
+    else:
+        return [target]
+
+
+def display(message, verbose=False, exit=0):
+    global show_time, show_verbose
+
+    if show_time:
+        now = datetime.datetime.now()
+        timestamp = datetime.datetime.strftime(now, '%Y/%m/%d %H:%M:%S')
+        message = '{} {}'.format(timestamp, message)
+
+    out = sys.stdout
+    if exit > 0:
+        out = sys.stderr
+
+    if verbose and show_verbose:
+        out.write(message.rstrip() + '\n')
+    elif not verbose:
+        out.write(message.rstrip() + '\n')
+
+    if exit > 0:
+        sys.exit(exit)
+
+
+def find_files(paths, pattern='.', partial=False):
+    paths = make_list(paths)
+    files = []
+    pattern_re = re.compile(pattern, re.I)
+
+    for item in paths:
+        if os.path.isfile(item):
+            files.append(item)
+        elif os.path.isdir(item):
+            for (root, dirs, filenames) in os.walk(item):
+                matched_files = [f for f in filenames if pattern_re.match(f)]
+                files.extend([os.path.join(root, f) for f in matched_files])
+        elif len(os.path.split(item)) > 1 and partial is False:
+            files.extend(find_files(os.path.dirname(item), os.path.basename(item), True))
+
+    return files
+
+
+def find_audits(paths):
+    audits = find_files(paths)
+    if len(audits) < 1:
+        display('No audits to process.', exit=True)
+    else:
+        s = ''
+        if len(audits) > 1: s = 's'
+        display('{} audit{} to process.'.format(len(audits), s), verbose=True)
+    return sorted(audits)
+
+
+def update_check_type(line):
+    global db_type_re
+    types = db_type_re.search(line)
+    if types is not None:
+        if types.groups()[1] == 'DB2':
+            new_type = 'IBM_DB2DB'
+        elif types.groups()[1] == 'SQLServer':
+            new_type = 'MS_SQLDB'
+        elif types.groups()[1] == 'sybase':
+            new_type = 'SybaseDB'
+        else:
+            new_type = '{}DB'.format(types.groups()[1])
+        new_line = line.replace(types.groups()[0], new_type)
+        return '{}">'.format(new_line[:new_line.index(new_type) + len(new_type)])
+    return line
+
+
+def read_audit_lines(audit):
+    global check_type_re, db_type_re
+    lines = []
+
+    found = False
+    with open(audit, 'r') as a_in:
+        while True:
+            line = a_in.readline()
+            if not line:
+                break
+            elif found:
+                lines.append(line.rstrip())
+            else:
+                if check_type_re.search(line):
+                    if db_type_re.search(line):
+                        found = True
+                    else:
+                        return None
+                lines.append(line.rstrip())
+
+    if not found: return None
+
+    return lines
+
+
+def convert_audit(audit):
+    global db_type_re, field_replace_re, group_policy_re, sql_field_re, simple_quoted_field_re, simple_unquoted_field_re, select_re
+    display('Processing {}'.format(audit))
+
+    display(' - reading audit', verbose=True)
+    lines = read_audit_lines(audit)
+    if lines is None:
+        display(' * audit not supported')
+        return None
+
+    del_lines = []
+    sql_request = None
+    sql_types = None
+    sql_expect = None
+    in_item = False
+    for i in range(len(lines)):
+        if db_type_re.search(lines[i]):
+            display(' - updating check type ({})'.format(i + 1), verbose=True)
+            lines[i] = update_check_type(lines[i])
+        elif group_policy_re.search(lines[i]):
+            display(' - adding group policy line to delete ({})'.format(i + 1), verbose=True)
+            del_lines.append(i)
+        elif sql_field_re.search(lines[i]):
+            name = sql_field_re.findall(lines[i])[0][0]
+            if name == 'sql_expect':
+                sql_expect = i
+            elif name == 'sql_types':
+                sql_types = i
+            elif name == 'sql_request':
+                sql_request = i
+        elif open_item_re.search(lines[i]):
+            if in_item:
+                display(' * opening of already open item ({})'.format(i + 1))
+            in_item = True
+        elif close_item_re.search(lines[i]):
+            if not in_item:
+                display(' * closing of non-open item ({})'.format(i + 1))
+            if sql_types is None or sql_expect is None:
+                display(' * did not find sql_types and sql_expect ({})'.format(i + 1))
+            else:
+                expect_vals = ':'.join(lines[sql_expect].split(':')[1:])
+                parsed = sql_util.parse_expect(expect_vals)
+                computed = [sql_util.compute_type_and_expect(p) for p in parsed]
+                line = '{}{}'.format(field_replace_re.findall(lines[sql_types])[0], ', '.join([c[0] for c in computed]))
+                lines[sql_types] = line
+                line = '{}{}'.format(field_replace_re.findall(lines[sql_expect])[0], ', '.join([c[1] for c in computed]))
+                lines[sql_expect] = line
+#                if sql_request_fields is not None and len(sql_request_fields) != len(computed):
+                if sql_request is not None:
+                    parts = lines[sql_request].split(':')
+                    value = ':'.join(parts[1:]).strip(' \'"')
+                    found = select_re.findall(value)
+                    columns = []
+                    if len(found) == 1:
+                        columns = [i.strip() for i in found[0].split(',')]
+                        if len(computed) > 1 and len(computed) != len(columns):
+                            display(' * possible mis-match of selected columns and defined values ({}): {} <> {}'.format(sql_request, len(computed), len(columns)))
+            sql_request_fields = None
+            sql_types = None
+            sql_expect = None
+            in_item = False
+        elif simple_quoted_field_re.search(lines[i]):
+            name = lines[i].split(':')[0].strip()
+            if name not in ('sql_request', 'info', 'solution', 'description', 'see_also', 'reference'):
+                display(' * commenting out unsupported quoted field ({}): {}'.format(i + 1, name))
+                lines[i] = '#{}'.format(lines[i])
+        elif simple_unquoted_field_re.search(lines[i]):
+            name = lines[i].split(':')[0].strip()
+            if name not in ('type', 'num_rows', 'severity'):
+                display(' * commenting out unsupported unquoted field ({}): {}'.format(i + 1, name))
+                lines[i] = '#{}'.format(lines[i])
+
+    if len(del_lines) > 0:
+        display(' - deleting lines', verbose=True)
+        for i in reversed(sorted(del_lines)):
+            del lines[i]
+
+    return '\n'.join(lines)
+
+
+def write_file(audit, data, output, replace=False):
+    if not os.path.isdir(output):
+        try:
+            os.mkdir(output)
+        except:
+            display('Unable to create ouput directory: {}'.format(output), exit=True)
+
+    name = os.path.basename(audit)
+    filepath = os.path.join(output, name)
+
+    if os.path.isfile(filepath) and not replace:
+        display('Unable to overwrite file: {}'.format(filepath), exit=True)
+
+    with open(filepath, 'w') as f_out:
+        f_out.write(data + '\n')
+
+    display('Wrote data to file: {}'.format(filepath))
+
+
+if __name__ == '__main__':
+    args = parse_args(sys.argv[1:])
+    display('Start', verbose=True)
+
+    audits = find_audits(args.audit)
+
+    for audit in audits:
+        data = convert_audit(audit)
+        if data is None:
+            continue
+        write_file(audit, data, args.output, args.replace)
+
+    display('Done', verbose=True)

--- a/db_audit_migrate/db_audit_migrate.py
+++ b/db_audit_migrate/db_audit_migrate.py
@@ -216,7 +216,6 @@ def convert_audit(audit):
                 lines[sql_types] = line
                 line = '{}{}'.format(field_replace_re.findall(lines[sql_expect])[0], ', '.join([c[1] for c in computed]))
                 lines[sql_expect] = line
-#                if sql_request_fields is not None and len(sql_request_fields) != len(computed):
                 if sql_request is not None:
                     parts = lines[sql_request].split(':')
                     value = ':'.join(parts[1:]).strip(' \'"')

--- a/db_audit_migrate/db_audit_migrate.py
+++ b/db_audit_migrate/db_audit_migrate.py
@@ -24,10 +24,10 @@ group_policy_re = re.compile('^\\s*</?\\s*group_policy\\s*(:\\s*"([^"]+)"\\s*)?>
 open_item_re = re.compile('^\\s*<\\s*custom_item\\s*>')
 close_item_re = re.compile('^\\s*</\\s*custom_item\\s*>')
 field_replace_re = re.compile('^(\\s*[^\\s:]+\\s*: *).*$')
-sql_field_re = re.compile('^ *(sql_(request|types|expect)) *: .*')
-simple_quoted_field_re = re.compile('^ *([a-z0-9_-]+) *: *(["\'])[^\\2]*\\2 *$')
-simple_unquoted_field_re = re.compile('^ *([a-z0-9_-]+) *: *[A-Za-z0-9_-]+ *$')
-select_re = re.compile('(?i)^select (.*?) from')
+sql_field_re = re.compile('^\\s*(sql_(request|types|expect))\\s*:\\s.*')
+simple_quoted_field_re = re.compile('^\\s*([a-z0-9_-]+)\\s*:\\s*(["\'])[^\\2]*\\2\\s*$')
+simple_unquoted_field_re = re.compile('^\\s*([a-z0-9_-]+)\\s*:\\s*[A-Za-z0-9_-]+\\s*$')
+select_re = re.compile('(?i)^select\\s(.*?) from')
 
 
 def parse_args(parameters):

--- a/db_audit_migrate/sql_util.py
+++ b/db_audit_migrate/sql_util.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+
+import re
+
+type_map = {
+    'POLICY_INTEGER': 'INTEGER',
+    'POLICY_VARCHAR': 'STRING'
+}
+
+integer_re = re.compile(r'^[0-9]+$')
+range_re = re.compile(r'^\[(MIN|@[^ ]*@|[0-9]+)\.\.(MAX|@[^ ]*@|[0-9]+)\]$')
+regex_re = re.compile(r'^regex *: *["\']')
+
+
+def parse_types(target):
+    types = [t.strip() for t in target.split(',')]
+
+    return [type_map[t] for t in types]
+
+
+def type_of(target):
+    global integer_re, range_re, regex_re
+
+    if target == 'NULL':
+        return 'NULL'
+    elif target == 'NO_ROWS_RETURNED':
+        return 'STRING'
+    elif len(target) > 1 and target[0] in '"\'' and target[0] == target[-1]:
+        return 'STRING'
+    elif len(target) > 1 and target[0] == '@' and target[0] == target[-1]:
+        return 'INTEGER'      # variables outside of quotes are integers
+    elif integer_re.search(target):
+        return 'INTEGER'
+    elif regex_re.search(target):
+        return 'REGEX'
+    elif range_re.search(target):
+        return 'RANGE'
+    else:
+        return 'UNKNOWN'
+
+
+def _parse_string(target, i, stop):
+    e = target.index(stop, i + 1)
+    while target[e - 1] in '\\':
+        e = target.index(stop, e + 1)
+    val = target[i:e + 1]
+    return val, e
+
+
+def parse_expect(target):
+    result = []
+
+    idx = 0 
+    i = 0
+    while i < len(target):
+        val = None
+        if target[i] in '"\'':
+            val, i = _parse_string(target, i, target[i])
+        elif target[i] in '[':
+            val, i = _parse_string(target, i, ']')
+        elif target[i] in '@':
+            val, i = _parse_string(target, i, '@')
+        elif target[i] in '1234567890':
+            e = i
+            while e + 1 < len(target) and target[e + 1] in '1234567890':
+                e += 1
+            val = target[i:e + 1]
+            i = e
+        elif target[i] in 'r' and target[i:i + 5] == 'regex':
+            i = i + 5
+            while target[i] not in '"\'': i += 1
+            re_val, i = _parse_string(target, i, target[i])
+            val = 'regex:{}'.format(re_val)
+        elif target[i] in 'N' and target[i:i + 4] == 'NULL':
+            val = 'NULL'
+            i = i + 3
+        elif target[i] in 'N' and target[i:i + 16] == 'NO_ROWS_RETURNED':
+            val = 'NO_ROWS_RETURNED'
+            i = i + 15
+        elif target[i] in ' |':
+            pass
+        elif target[i] in ',':
+            idx += 1
+        else:
+            raise Exception(target[i])
+
+        if val is None:
+            pass
+        else:
+            val_type = (type_of(val), val)
+            if idx == len(result):
+                result.append(val_type)
+            else:
+                if result[-1][0] == 'COMPLEX':
+                    result[-1][1].append(val_type)
+                else:
+                    result[-1] = ('COMPLEX', [result[-1], val_type])
+        i += 1
+
+    return result
+
+
+def compute_type_and_expect(target):
+    val_type = target[0]
+    val_expect = target[1]
+
+    if val_type == 'RANGE':
+        val_type = 'INTEGER'
+    elif val_type == 'COMPLEX':
+        # if range in list... can't support yet
+        if 'RANGE' in [v[0] for v in val_expect[1]]:
+            raise Exception('Unable to process complex range: {}'.format(val_type))
+        # check if any NULL and update or_null
+        or_null = ''
+        for i in reversed(range(len(val_expect))):
+            if val_expect[i][0] == 'NULL':
+                or_null = '_OR_NULL'
+                del val_expect[i]
+
+        # if multiple values still exist, collapse to REGEX
+        vals = [v[1].replace('regex:', '').strip('"\'') for v in val_expect]
+        if len(vals) > 1:
+            val_type = 'REGEX'
+            val_expect = '"^({})$"'.format('|'.join(vals))
+        else:
+            val_type = val_expect[0][0]
+            val_expect = val_expect[0][1].replace('regex:', '')
+
+        val_type = '{}{}'.format(val_type, or_null)
+    else:
+        val_expect = val_expect.replace('regex:', '')
+
+    # make sure value is double quoted
+    if len(val_expect) >=2 and val_expect[0] == "'":
+        val = val_expect[1:-1].replace('"', '\\"')
+        val_expect = '"{}"'.format(val)
+
+    return (val_type, val_expect)
+
+
+

--- a/db_audit_migrate/sql_util_test.py
+++ b/db_audit_migrate/sql_util_test.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+
+import sql_util
+
+def test_parse_types():
+    assert sql_util.parse_types("POLICY_INTEGER") == ["INTEGER"]
+    assert sql_util.parse_types("POLICY_INTEGER, POLICY_INTEGER") == ["INTEGER", "INTEGER"]
+    assert sql_util.parse_types("POLICY_INTEGER, POLICY_VARCHAR") == ["INTEGER", "STRING"]
+    assert sql_util.parse_types("POLICY_INTEGER, POLICY_VARCHAR, POLICY_INTEGER") == ["INTEGER", "STRING", "INTEGER"]
+    assert sql_util.parse_types("POLICY_INTEGER,POLICY_VARCHAR,POLICY_INTEGER") == ["INTEGER", "STRING", "INTEGER"]
+    assert sql_util.parse_types("POLICY_INTEGER,POLICY_VARCHAR,POLICY_VARCHAR") == ["INTEGER", "STRING", "STRING"]
+    assert sql_util.parse_types("POLICY_VARCHAR") == ["STRING"]
+    assert sql_util.parse_types("POLICY_VARCHAR, POLICY_INTEGER") == ["STRING", "INTEGER"]
+    assert sql_util.parse_types("POLICY_VARCHAR, POLICY_INTEGER, POLICY_INTEGER") == ["STRING", "INTEGER", "INTEGER"]
+    assert sql_util.parse_types("POLICY_VARCHAR, POLICY_VARCHAR") == ["STRING", "STRING"]
+    assert sql_util.parse_types("POLICY_VARCHAR, POLICY_VARCHAR, POLICY_INTEGER") == ["STRING", "STRING", "INTEGER"]
+    assert sql_util.parse_types("POLICY_VARCHAR,POLICY_INTEGER") == ["STRING", "INTEGER"]
+    assert sql_util.parse_types("POLICY_VARCHAR,POLICY_INTEGER,POLICY_INTEGER") == ["STRING", "INTEGER", "INTEGER"]
+    assert sql_util.parse_types("POLICY_VARCHAR,POLICY_INTEGER,POLICY_VARCHAR") == ["STRING", "INTEGER", "STRING"]
+    assert sql_util.parse_types("POLICY_VARCHAR,POLICY_VARCHAR") == ["STRING", "STRING"]
+    assert sql_util.parse_types("POLICY_VARCHAR,POLICY_VARCHAR,POLICY_INTEGER") == ["STRING", "STRING", "INTEGER"]
+
+
+def test_type_of():
+    assert sql_util.type_of('""') == 'STRING'
+    assert sql_util.type_of("''") == 'STRING'
+    assert sql_util.type_of('"ABC"') == 'STRING'
+    assert sql_util.type_of('"DEF ZYX"') == 'STRING'
+    assert sql_util.type_of('"@DEF ZYX@"') == 'STRING'
+    assert sql_util.type_of('"DEF \\"ZYX\\""') == 'STRING'
+    assert sql_util.type_of('0') == 'INTEGER'
+    assert sql_util.type_of('10') == 'INTEGER'
+    assert sql_util.type_of('908') == 'INTEGER'
+    assert sql_util.type_of('regex:"ABC"') == 'REGEX'
+    assert sql_util.type_of('regex: "DEF \\"ZYX\\""') == 'REGEX'
+    assert sql_util.type_of("regex: 'DEF ZYX'") == 'REGEX'
+    assert sql_util.type_of('NULL') == 'NULL'
+    assert sql_util.type_of('[1..5]') == 'RANGE'
+    assert sql_util.type_of('[1..MAX]') == 'RANGE'
+    assert sql_util.type_of('9.08') == 'UNKNOWN'
+    assert sql_util.type_of('null') == 'UNKNOWN'
+
+
+def test_parse_expect():
+    assert sql_util.parse_expect("\"\"") == [('STRING', '""')]
+    assert sql_util.parse_expect("\"\", \"\"") == [('STRING', '""'), ('STRING', '""')]
+    assert sql_util.parse_expect("\"\", \"35 or less\"") == [('STRING', '""'), ('STRING', '"35 or less"')]
+    assert sql_util.parse_expect("\"ABC DEF GHI\"") == [('STRING', '"ABC DEF GHI"')]
+    assert sql_util.parse_expect("\".+\",@MAX_FILES@") == [('STRING', '".+"'), ('INTEGER', '@MAX_FILES@')]
+    assert sql_util.parse_expect("\"0\"") == [('STRING', '"0"')]
+    assert sql_util.parse_expect("\"0\", regex:\"Last Password.*\"") == [('STRING', '"0"'), ('REGEX', 'regex:"Last Password.*"')]
+    assert sql_util.parse_expect("\"1\"") == [('STRING', '"1"')]
+    assert sql_util.parse_expect("\"1\", \"0\"") == [('STRING', '"1"'), ('STRING', '"0"')]
+    assert sql_util.parse_expect("\"@ADMIN_USER@\", regex:\".+\"") == [('STRING', '"@ADMIN_USER@"'), ('REGEX', 'regex:".+"')]
+    assert sql_util.parse_expect("\"@JOB_QUEUE_PROC@\"") == [('STRING', '"@JOB_QUEUE_PROC@"')]
+    assert sql_util.parse_expect("\"@SA_ACCOUNT@\", 1") == [('STRING', '"@SA_ACCOUNT@"'), ('INTEGER', '1')]
+    assert sql_util.parse_expect("\"ALERT\" || \"LOG\"") == [('COMPLEX', [('STRING', '"ALERT"'), ('STRING', '"LOG"')])]
+    assert sql_util.parse_expect("\"AES_128\"||\"AES_192\"||\"AES_256\"||\"Triple_DES\"") == [('COMPLEX', [('STRING', '"AES_128"'), ('STRING', '"AES_192"'), ('STRING', '"AES_256"'), ('STRING', '"Triple_DES"')])]
+    assert sql_util.parse_expect("\"EXCLUSIVE\" || \"NONE\"") == [('COMPLEX', [('STRING', '"EXCLUSIVE"'), ('STRING', '"NONE"')])]
+    assert sql_util.parse_expect("0") == [('INTEGER', '0')]
+    assert sql_util.parse_expect("102") == [('INTEGER', '102')]
+    assert sql_util.parse_expect("@ABC@") == [('INTEGER', '@ABC@')]
+    assert sql_util.parse_expect("4 || 6") == [('COMPLEX', [('INTEGER', '4'), ('INTEGER', '6')])]
+    assert sql_util.parse_expect("4 || 6, \"ON\"") == [('COMPLEX', [('INTEGER', '4'), ('INTEGER', '6')]), ('STRING', '"ON"')]
+    assert sql_util.parse_expect("NULL") == [('NULL', 'NULL')]
+    assert sql_util.parse_expect("NULL, NULL") == [('NULL', 'NULL'), ('NULL', 'NULL')]
+    assert sql_util.parse_expect("\"ManualReviewRequired\", NULL") == [('STRING', '"ManualReviewRequired"'), ('NULL', 'NULL')]
+    assert sql_util.parse_expect("NULL || \"FALSE\"") == [('COMPLEX', [('NULL', 'NULL'), ('STRING', '"FALSE"')])]
+    assert sql_util.parse_expect("NULL || regex: \"[Ff][Aa][Ll][Ss][Ee]\"") == [('COMPLEX', [('NULL', 'NULL'), ('REGEX', 'regex:"[Ff][Aa][Ll][Ss][Ee]"')])]
+    assert sql_util.parse_expect("[1..100]") == [('RANGE', '[1..100]')]
+    assert sql_util.parse_expect("[1..3]") == [('RANGE', '[1..3]')]
+    assert sql_util.parse_expect("[1..@PG_KEEPALIVES_COUNT@]") == [('RANGE', '[1..@PG_KEEPALIVES_COUNT@]')]
+    assert sql_util.parse_expect("[4..MAX]") == [('RANGE', '[4..MAX]')]
+    assert sql_util.parse_expect("[MIN..MAX]") == [('RANGE', '[MIN..MAX]')]
+    assert sql_util.parse_expect("[12..429496729]") == [('RANGE', '[12..429496729]')]
+
+
+def test_compute_type_and_expect_simple():
+    assert sql_util.compute_type_and_expect(('NULL', 'NULL')) == ('NULL', 'NULL')
+    assert sql_util.compute_type_and_expect(('STRING', '""')) == ('STRING', '""')
+    assert sql_util.compute_type_and_expect(('STRING', '"@ADMIN_USER@"')) == ('STRING', '"@ADMIN_USER@"')
+    assert sql_util.compute_type_and_expect(('INTEGER', '0')) == ('INTEGER', '0')
+    assert sql_util.compute_type_and_expect(('INTEGER', '102')) == ('INTEGER', '102')
+    assert sql_util.compute_type_and_expect(('INTEGER', '@ABC@')) == ('INTEGER', '@ABC@')
+    assert sql_util.compute_type_and_expect(('REGEX', 'regex:"@ABC@"')) == ('REGEX', '"@ABC@"')
+
+
+def test_compute_type_and_expect_range():
+    assert sql_util.compute_type_and_expect(('RANGE', '[1..100]')) == ('INTEGER', '[1..100]')
+    assert sql_util.compute_type_and_expect(('RANGE', '[1..3]')) == ('INTEGER', '[1..3]')
+    assert sql_util.compute_type_and_expect(('RANGE', '[1..@PG_KEEPALIVES_COUNT@]')) == ('INTEGER', '[1..@PG_KEEPALIVES_COUNT@]')
+    assert sql_util.compute_type_and_expect(('RANGE', '[4..MAX]')) == ('INTEGER', '[4..MAX]')
+    assert sql_util.compute_type_and_expect(('RANGE', '[MIN..MAX]')) == ('INTEGER', '[MIN..MAX]')
+    assert sql_util.compute_type_and_expect(('RANGE', '[12..429496729]')) == ('INTEGER', '[12..429496729]')
+
+
+def test_compute_type_and_expect_complex():
+    assert sql_util.compute_type_and_expect(('COMPLEX', [('STRING', '"ALERT"'), ('STRING', '"LOG"')])) == ('REGEX', '"^(ALERT|LOG)$"')
+    assert sql_util.compute_type_and_expect(('COMPLEX', [('STRING', '"AES_128"'), ('STRING', '"AES_192"'), ('STRING', '"AES_256"'), ('STRING', '"Triple_DES"')])) == ('REGEX', '"^(AES_128|AES_192|AES_256|Triple_DES)$"')
+    assert sql_util.compute_type_and_expect(('COMPLEX', [('STRING', '"EXCLUSIVE"'), ('STRING', '"NONE"')])) == ('REGEX', '"^(EXCLUSIVE|NONE)$"')
+    assert sql_util.compute_type_and_expect(('COMPLEX', [('REGEX', 'regex:"TRUE"'), ('REGEX', 'regex:"FALSE"')])) == ('REGEX', '"^(TRUE|FALSE)$"')
+    assert sql_util.compute_type_and_expect(('COMPLEX', [('INTEGER', '4'), ('INTEGER', '6')])) == ('REGEX', '"^(4|6)$"')
+    assert sql_util.compute_type_and_expect(('COMPLEX', [('INTEGER', '4'), ('INTEGER', '6'), ('STRING', '"ON"')])) == ('REGEX', '"^(4|6|ON)$"')
+    assert sql_util.compute_type_and_expect(('COMPLEX', [('INTEGER', '1'), ('NULL', 'NULL')])) == ('INTEGER_OR_NULL', '1')
+    assert sql_util.compute_type_and_expect(('COMPLEX', [('NULL', 'NULL'), ('STRING', '"FALSE"')])) == ('STRING_OR_NULL', '"FALSE"')
+    assert sql_util.compute_type_and_expect(('COMPLEX', [('NULL', 'NULL'), ('REGEX', 'regex:"[Ff][Aa][Ll][Ss][Ee]"')])) == ('REGEX_OR_NULL', '"[Ff][Aa][Ll][Ss][Ee]"')


### PR DESCRIPTION
Script to attempt to convert a legacy "Database" audit to the more targeted audit format.

If something can not be migrated, the script should produce a warning and line number to look at.